### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ Model Context Protocol server for Trino, providing AI models with structured acc
 ⚠️ **BETA RELEASE (v0.1.2)** ⚠️  
 This project is stabilizing with core features working and tested. Feel free to fork and contribute!
 
+<a href="https://glama.ai/mcp/servers/j0qhebd1qw">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/j0qhebd1qw/badge" alt="Trino Server MCP server" />
+</a>
+
 ## Features
 
 - ✅ Fixed Docker container API initialization issue! (reliable server initalization)
@@ -524,7 +528,7 @@ The standalone API defaults to port 8008 to avoid conflicts. If you see an "addr
    ```
 
 2. Run with a custom port via command line:
-   ```bash
+   ```python
    python -c "import llm_trino_api; import uvicorn; uvicorn.run(llm_trino_api.app, host='127.0.0.1', port=8009)"
    ```
 


### PR DESCRIPTION
This PR adds a badge for the [Trino MCP Server](https://glama.ai/mcp/servers/j0qhebd1qw) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/j0qhebd1qw">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/j0qhebd1qw/badge" alt="Trino Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.